### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,17 @@ rvm:
   - 2.4.1
 
 script: ./travis_scripts/build.sh
-  
+
+env:
+  global:
+    # This speeds up the installation of html-proofer
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+addons:
+  apt:
+    packages:
+      # We need this to check https links
+      - libcurl4-openssl-dev
+
 # Caching bundler gem packages will speed up the build
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
 rvm:
-  - 2.5.1
+  - 2.4.1
 
 before_install:
   - gem update --system
 
-script: bundle exec jekyll build
+script: ./travis_scripts/build.sh
   
 # Caching bundler gem packages will speed up the build
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 2.5.1
+
+before_install:
+  - gem update --system
+
+script: bundle exec jekyll build
+  
+# Caching bundler gem packages will speed up the build
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: ruby
 rvm:
   - 2.4.1
 
-before_install:
-  - gem update --system
-
 script: ./travis_scripts/build.sh
   
 # Caching bundler gem packages will speed up the build

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'jekyll'
 gem 'jekyll-redirect-from'
+gem 'html-proofer', :group => :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     colorator (1.1.0)
+    colorize (0.8.1)
+    concurrent-ruby (1.0.5)
+    ethon (0.11.0)
+      ffi (>= 1.3.0)
     ffi (1.9.18)
     forwardable-extended (2.6.0)
+    html-proofer (3.9.2)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colorize (~> 0.8)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.8.1)
+      parallel (~> 1.3)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+    i18n (1.1.1)
+      concurrent-ruby (~> 1.0)
     jekyll (3.5.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -29,6 +49,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+    parallel (1.12.1)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
@@ -42,13 +67,20 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    thread_safe (0.3.6)
+    typhoeus (1.3.0)
+      ethon (>= 0.9.0)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-proofer
   jekyll
   jekyll-redirect-from
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/pages/18-01.md
+++ b/pages/18-01.md
@@ -86,8 +86,9 @@ certificate-related warnings.
 In 2015, [OMB M-15-13](https://https.cio.gov/) required all existing
 Federal websites and web services to be accessible through a secure
 connection (HTTPS-only, with HSTS). In 2017, the .gov registry began
-[automatically preloading](https://home.dotgov.gov/hsts-preloading/) new federal .gov domains as HSTS-only in modern
-browsers.
+[automatically
+preloading](https://home.dotgov.gov/management/preloading/) new
+federal .gov domains as HSTS-only in modern browsers.
 
 Federal agencies must make more progress on HTTPS and HSTS
 deployment, including by removing support for known-weak cryptographic

--- a/travis_scripts/build.sh
+++ b/travis_scripts/build.sh
@@ -2,3 +2,4 @@
 
 npm install
 bundle exec jekyll build
+bundle exec htmlproofer ./_site

--- a/travis_scripts/build.sh
+++ b/travis_scripts/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+npm install
+bundle exec jekyll build

--- a/travis_scripts/build.sh
+++ b/travis_scripts/build.sh
@@ -2,4 +2,5 @@
 
 npm install
 bundle exec jekyll build
-bundle exec htmlproofer ./_site
+# We want to ignore things like <a href="#">Return to top</a>
+bundle exec htmlproofer ./_site --url-ignore "/#/"


### PR DESCRIPTION
I'm far from an expert on Ruby, Jekyll, etc., but I believe these changes are sufficient to make TravisCI successfully build the site.  It looks like TravisCI has been failing for the past six months, so this is definitely an improvement.

I also added code to run `html-proofer` on the site to ensure that all the images and hyperlinks actually point to a real source.  This seems to have turned up [one error](https://travis-ci.com/dhs-ncats/cyber.dhs.gov/builds/89597805#L592-L593).  See below (or the most recent failed build) for details.