### PR TITLE
Fixing two broken links for the 18-01 FAQ.

### DIFF
--- a/pages/18-01.md
+++ b/pages/18-01.md
@@ -310,8 +310,8 @@ BOD 18-01 requires that these protocols and ciphers cease being offered on inter
 The directive also requires that agencies identify and provide a list to DHS of agency second-level domains that can be HSTS preloaded. Agencies should review their list of second-level domains (including any not yet using the .gov top-level domain, as required by [M-17-06](https://policy.cio.gov/web-policy/domain/)) and analyze which can be preloaded.
 
 #### See the [Compliance Guide](#compliance-guide) below for more info.
-* [How does the web security requirement in BOD 18-01 differ from M-15-13?](/#how-does-the-web-security-requirement-in-bod-18-01-differ-from-m-15-13)
-* [How should the list of second-level domains to be preloaded be shared with DHS?](/#how-should-the-list-of-second-level-domains-to-be-preloaded-be-shared-with-dhs)
+* [How does the web security requirement in BOD 18-01 differ from M-15-13?](#how-does-the-web-security-requirement-in-bod-18-01-differ-from-m-15-13)
+* [How should the list of second-level domains to be preloaded be shared with DHS?](#how-should-the-list-of-second-level-domains-to-be-preloaded-be-shared-with-dhs)
 * [https.cio.gov contains the M-15-13 compliance guide](https://https.cio.gov/guide/), which should be followed in implementing the HTTPS/HSTS requirements of BOD-18-01. See also:
   * [Introduction to HTTPS](https://https.cio.gov/faq/)
   * [HTTP Strict Transport Security](https://https.cio.gov/hsts/)


### PR DESCRIPTION
- corrected two FAQ links which were not resolving and pointed to the incorrect location.