### PR TITLE
Add CVD links to 20-01 guidance

### DIFF
--- a/pages/20-01.md
+++ b/pages/20-01.md
@@ -455,14 +455,14 @@ Where this occurs, your agency should still take care to ensure the discoverabil
 #### *In use by your agency*
 When including systems or services in your policy’s scope that incorporate third-party products or services (for example, from cloud service providers), take counsel from the Department of Justice’s guidance ([step 1(C)](https://www.justice.gov/criminal-ccips/page/file/983996/download#page=4)) and consider which components can be included in your VDP. Once you’ve made that determination, take care to specify what is and isn’t in scope for authorized testing, and how one can tell (for example, clearly name the set of domain names that are in-bounds).
 
-Should your agency lack an appropriate contact at commercial software or hardware vendors, CISA can help coordinate disclosure. Get in touch at [https://www.us-cert.gov/report](https://www.us-cert.gov/report).
+Should your agency lack an appropriate contact at commercial software or hardware vendors, CISA can help coordinate disclosure. Get in touch through [https://www.cisa.gov/coordinated-vulnerability-disclosure-process](https://www.cisa.gov/coordinated-vulnerability-disclosure-process).
 
 #### *Sent to you because of a real or perceived regulatory role*
 Your agency may receive reports covering the online services of organizations in the sector your agency participates in or oversees. To communicate expectations, you might consider sharing something about this in your VDP:
 
 `Vulnerabilities in {aviation, financial systems} should be reported to the vendor or system owner, not to the {Federal Aviation Administration, Department of the Treasury}.`
 
-If vulnerabilities are reported to your agency anyway, your agency should still make a good faith effort to relay them to the appropriate party. CISA [may be able to assist](https://www.us-cert.gov/report) in coordinating such reports when received by your agency.
+If vulnerabilities are reported to your agency anyway, your agency should still make a good faith effort to relay them to the appropriate party. CISA [may be able to assist](https://www.cisa.gov/coordinated-vulnerability-disclosure-process) in coordinating such reports when received by your agency.
 
 ### Use the web
 Consider using a web form or a dedicated web application to accept vulnerability reports and encouraging reporters to use it. Submissions delivered via the web are likely to be better protected in transit than via email, and web forms enable your agency to standardize the format of vulnerability reports. Done well, they enable more structured communication that is less likely to be subject to misinterpretation. Web forms can also mark certain fields as mandatory, reducing the need to follow up with the reporter unnecessarily. There exist third party web-based commercial services that are designed for the specific purpose of helping organizations receive high-quality, well-structured vulnerability reports.


### PR DESCRIPTION
This small change points some implementation guidance links at the updated CISA coordinated vulnerability disclosure process doc, which was [formerly](https://web.archive.org/web/20190924063100/https://www.us-cert.gov/vulnerability-disclosure-policy) (and somewhat misleadingly) named a VDP.