### PR TITLE
Resolves #103, Explicit requirement for inclusion of agency OGC in policy development

### DIFF
--- a/pages/20-01-vdp-template.md
+++ b/pages/20-01-vdp-template.md
@@ -117,7 +117,7 @@ will work with you to understand and resolve the issue quickly, and
 *AGENCY NAME* will not recommend or pursue legal action related to your
 research.
 
-The Office of General Counsel, Office of Inspector General, and all
+The Office of General Counsel (OGC), Office of Inspector General (OIG), and all
 other appropriate legal authorities at *AGENCY NAME* have reviewed
 and support this policy's commitments.
 

--- a/pages/20-01-vdp-template.md
+++ b/pages/20-01-vdp-template.md
@@ -117,6 +117,10 @@ will work with you to understand and resolve the issue quickly, and
 *AGENCY NAME* will not recommend or pursue legal action related to your
 research.
 
+The Office of General Counsel, Office of Inspector General, and all
+other appropriate legal authorities at *AGENCY NAME* have reviewed
+and support this policy's commitments.
+
 ### Scope
 
 <span style="color:red">*This section defines which internet-accessible systems or services are

--- a/pages/20-01-vdp-template.md
+++ b/pages/20-01-vdp-template.md
@@ -117,10 +117,6 @@ will work with you to understand and resolve the issue quickly, and
 *AGENCY NAME* will not recommend or pursue legal action related to your
 research.
 
-The Office of General Counsel (OGC), Office of Inspector General (OIG), and all
-other appropriate legal authorities at *AGENCY NAME* have reviewed
-and support this policy's commitments.
-
 ### Scope
 
 <span style="color:red">*This section defines which internet-accessible systems or services are

--- a/pages/20-01.md
+++ b/pages/20-01.md
@@ -223,12 +223,18 @@ Within 180 calendar days after the issuance of this directive:
             agency concludes represents a good faith effort to follow
             the policy, and *deem that activity authorized*.
 
-      >v.  *A statement that sets expectations* for when the reporter
+      >v.  *An explicit statement that an agency's Office of General
+            Counsel (OGC), Office of Inspector General (OIG), and/or
+            any other appropriate legal organizations at the agency have
+            reviewed and concurred to all assertions regarding pursuit of
+            legal action against good faith researchers.
+
+      >vi.  *A statement that sets expectations* for when the reporter
             can anticipate acknowledgement of their report, *and pledges
             the agency to be as transparent as possible* about what
             steps it is taking during the remediation process*.*
 
-      >vi. *An issuance date.*[^12]
+      >vii. *An issuance date.*[^12]
 
     b)  The policy, or implementation of policy, **must not**:
 


### PR DESCRIPTION
The pull request adds a requirement that agencies consult their legal folks regarding any assertions related to pursuit of legal action made in their vulnerability disclosure policies.

As BODs tend to lean "techy" and will likely initially land amongst OCIO types, there may be value in explicitly requiring agencies work with their legally-minded organizations as they develop their vulnerability disclosure policies.

This pull requests resolves #103, Explicit requirement for inclusion of agency OGC in policy development.