### PR TITLE
Remove reward language in 20-01 guidance

### DIFF
--- a/pages/20-01.md
+++ b/pages/20-01.md
@@ -323,7 +323,7 @@ Answers to other common compliance questions appear below.
 * [How should we communicate with vulnerability reporters?](#how-should-we-communicate-with-vulnerability-reporters)
 * [Do we need to send a response to every vulnerability report?](#do-we-need-to-send-a-response-to-every-vulnerability-report)
 * [How should my agency treat vulnerability reports from anonymous sources?](#how-should-my-agency-treat-vulnerability-reports-from-anonymous-sources)
-* [Can we recognize vulnerability reporters for their efforts??](#can-we-recognize-vulnerability-reporters-for-their-efforts)
+* [Can we recognize vulnerability reporters for their efforts?](#can-we-recognize-vulnerability-reporters-for-their-efforts)
 
 **Miscellaneous**
 * [What is CISA’s role in my agency’s coordinated vulnerability disclosure efforts?](#what-is-cisas-role-in-my-agencys-coordinated-vulnerability-disclosure-efforts)
@@ -472,10 +472,6 @@ Obviously, if the source is unknown, you are not under any requirement to find o
 
 #### Can we recognize vulnerability reporters for their efforts?
 Yes. Some organizations publicly acknowledge people who relay confirmed or especially impactful reports on a webpage or in [social media](https://web.archive.org/web/20200730203649/https://twitter.com/DC3VDP/status/1278664041528000512?s=20). While a public 'thank you' is a generous practice, it must not be done unless you've received explicit permission from the reporter that they are comfortable with public acknowledgement.
-
-Rewards can also play a meaningful role, even if the reward is not monetary (which is generally referred to as a "[bug bounty](#can-we-operate-a-bug-bounty)"). For instance, the Netherlands' [National Cyber Security Centre](https://english.ncsc.nl/) is known for [rewarding quality reports](https://english.ncsc.nl/contact/reporting-a-vulnerability-cvd) that were previously unknown with, among other things, a t-shirt that reads "I hacked the Dutch government and all I got was this lousy t-shirt" ([pdf](https://english.ncsc.nl/binaries/ncsc-en/documents/publications/2019/juni/01/coordinated-vulnerability-disclosure-the-guideline/WEB_Brochure-NCSC_EN.pdf)). In their [VDP guidance](https://english.ncsc.nl/get-to-work/implement-a-cvd-policy/preparing-a-cvd-policy), the NCSC says that public and private recognition "creates a better relationship between the reporting party and the organisation. It also increases the willingness to submit new reports."
-
-Even if you don't choose to offer rewards – and healthy competition between agencies on the coolest vulnerability reporting swag would be a wonderful outcome of this directive – you may elect to include language in your VDP that makes clear your reward stance, which facilitates shared expectations from the start.
 
 ### Miscellaneous FAQ
 #### What is CISA’s role in my agency’s coordinated vulnerability disclosure efforts?


### PR DESCRIPTION
This change is to address current advice from OCC, removing language in the 20-01 guidance around rewards.