### PR TITLE
Update 20-04 script

### DIFF
--- a/assets/report/ed-20-04_script/CVE-2020-1472.ps1
+++ b/assets/report/ed-20-04_script/CVE-2020-1472.ps1
@@ -43,395 +43,440 @@ $allDCs | % {
 
     Get-WmiObject Win32_quickfixengineering -ComputerName $DC | Select-Object * | ForEach-Object{
         $Hotfix = $_.HotFixID
+        $Type = "CBS"
 
-        $result = switch ($Hotfix){
-            KB4571729 {
+        $result = switch ($Hotfix){   
+            KB4571729 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4571719 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4571736 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4571702 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4571703 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4571723 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4571694 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4565349 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4565351 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4566782 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4577051 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4577038 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4577066 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4577015 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4577069 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4574727 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4577062 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4571744 { 
+                $CBSObj = New-Object -TypeName psobject
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
+            }
+            KB4571756 { 
                 $CBSObj = New-Object -TypeName psobject
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
             }
-            KB4571719 {
+            KB4571748 { 
                 $CBSObj = New-Object -TypeName psobject
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
             }
-            KB4571736 {
+            KB4570333 { 
                 $CBSObj = New-Object -TypeName psobject
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
+                $CBSObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
                 $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
             }
-            KB4571702 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4571703 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4571723 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4571694 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4565349 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4565351 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4566782 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4577051 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4577038 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4577066 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4577015 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4577069 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4574727 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4577062 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4571744 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4571756 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4571748 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-            KB4570333 {
-                $CBSObj = New-Object -TypeName psobject
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $Hotfix
-                $CBSObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $CBSObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
-            }
-
+            
         }
     }
 
     Write-Host -ForegroundColor White ("INFORMATION: MSI Updates...")
     $((Invoke-Command -ComputerName $DC -ScriptBlock { $Session = New-Object -ComObject Microsoft.Update.Session ; $UpdateSearch = $Session.CreateUpdateSearcher() ; $UpdateSearch.Search("IsInstalled=1").Updates | select Title })) | % {
         $Title = $_.Title
+        $Type = "MSI"
 
-        $result = switch -Wildcard ($Title){
+        $result = switch -Wildcard ($Title){   
             "*4571729*" {
-                $KB = "KB4571729"
+                $KB = "KB4571729"  
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4571719*" {
-                $KB = "KB4571719"
+                $KB = "KB4571719" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4571736*" {
-                $KB = "KB4571736"
+                $KB = "KB4571736" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4571702*" {
-                $KB = "KB4571702"
+                $KB = "KB4571702" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4571703*" {
-                $KB = "KB4571703"
+                $KB = "KB4571703"  
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4571723*" {
-                $KB = "KB4571723"
+                $KB = "KB4571723"  
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
             }
             "*4571694*" {
-                $KB = "KB4571694"
+                $KB = "KB4571694" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation 
             }
             "*4565349*" {
-                $KB = "KB4565349"
+                $KB = "KB4565349" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4565351*" {
-                $KB = "KB4565351"
+                $KB = "KB4565351" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4566782*" {
-                $KB = "KB4566782"
+                $KB = "KB4566782" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4577051*" {
-                $KB = "KB4577051"
+                $KB = "KB4577051" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4577038*" {
-                $KB = "KB4577038"
+                $KB = "KB4577038" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4577066*" {
-                $KB = "KB4577066"
+                $KB = "KB4577066" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4577015*" {
-                $KB = "KB4577015"
+                $KB = "KB4577015" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4577069*" {
-                $KB = "KB4577069"
+                $KB = "KB4577069" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4574727*" {
-                $KB = "KB4574727"
+                $KB = "KB4574727" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4577062*" {
-                $KB = "KB4577062"
+                $KB = "KB4577062" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4571744*" {
-                $KB = "KB4571744"
+                $KB = "KB4571744" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4571756*" {
-                $KB = "KB4571756"
+                $KB = "KB4571756" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4571748*" {
-                $KB = "KB4571748"
+                $KB = "KB4571748" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
             "*4570333*" {
-                $KB = "KB4570333"
+                $KB = "KB4570333" 
                 $MSIObj = New-Object -TypeName psobject
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
                 $MSIObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
-                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True
-                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
+                $MSIObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $True 
+                $MSIObj | Export-Csv -path $UpdateList -Append -NoTypeInformation  
             }
-
-
+           
+            
         }
-
+        
     }
-
+    
 }
 
 if (Test-Path $UpdateList){
-    $CSV = Import-Csv -Path $UpdateList | select DomainController
+    $CSV = Import-Csv -Path $UpdateList | select DomainController -Unique
     $compare = Compare-Object -ReferenceObject $allDCs.hostname -DifferenceObject $CSV.DomainController
-    $compare | ForEach-Object {
-        $DC = $compare.Inputobject
+    foreach ($i in $compare) {
+        $DC = $i.Inputobject
         $OS = $(Get-WmiObject -ComputerName $DC -Class Win32_OperatingSystem).caption
         $KB = "No KB Installed for CVE-2020-1472"
+        $Type = "Not Relevant"
         $Compliance = $False
 
         $NullDCObj = New-Object -TypeName psobject
         $NullDCObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
         $NullDCObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
         $NullDCObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
+        $NullDCObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
         $NullDCObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $Compliance
         $NullDCObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
 
@@ -441,6 +486,7 @@ else{
     $allDCs | ForEach-Object {
         $DC = $_.Hostname
         $OS = $(Get-WmiObject -ComputerName $DC -Class Win32_OperatingSystem).caption
+        $Type = "Not Relevant"
         $KB = "No KB Installed for CVE-2020-1472"
         $Compliance = $False
 
@@ -448,6 +494,7 @@ else{
         $NullDCObj | Add-Member -MemberType NoteProperty -Name "DomainController" -Value $DC
         $NullDCObj | Add-Member -MemberType NoteProperty -Name "OperatingSystem" -Value $OS
         $NullDCObj | Add-Member -MemberType NoteProperty -Name "Update" -Value $KB
+        $NullDCObj | Add-Member -MemberType NoteProperty -Name "Type" -Value $Type
         $NullDCObj | Add-Member -MemberType NoteProperty -Name "Compliance" -Value $Compliance
         $NullDCObj | Export-Csv -path $UpdateList -Append -NoTypeInformation
     }


### PR DESCRIPTION
This PR fixes an error in the 2020-1472 patch validator caused by a misconception in how PowerShell [handles Compare-object](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/compare-object?view=powershell-7) objects.