### PR TITLE
Add NSCAI to the agency list

### DIFF
--- a/pages/agencylist.md
+++ b/pages/agencylist.md
@@ -74,8 +74,8 @@ The following civilian Executive Branch agencies fall under CISA's [authorities]
 | National Endowment for the Humanities | NEH
 | National Labor Relations Board| NLRB
 | National Mediation Board| NMB
-| National Security Commission on Artificial Intelligence | NSCAI
 | National Science Foundation | NSF
+| National Security Commission on Artificial Intelligence | NSCAI
 | National Transportation Safety Board| NTSB
 | Nuclear Regulatory Commission | NRC
 | Nuclear Waste Technical Review Board| NWTRB

--- a/pages/agencylist.md
+++ b/pages/agencylist.md
@@ -68,13 +68,13 @@ The following civilian Executive Branch agencies fall under CISA's [authorities]
 | National Aeronautics and Space Administration | NASA
 | National Archives and Records Administration| NARA
 | National Capital Planning Commission| NCPC
-| National Commission on Military, National, and Public Service  | NCMNPS
 | National Council on Disability| NCD
 | National Credit Union Administration| NCUA
 | National Endowment for the Arts | NEA
 | National Endowment for the Humanities | NEH
 | National Labor Relations Board| NLRB
 | National Mediation Board| NMB
+| National Security Commission on Artificial Intelligence | NSCAI
 | National Science Foundation | NSF
 | National Transportation Safety Board| NTSB
 | Nuclear Regulatory Commission | NRC


### PR DESCRIPTION
[National Security Commission on Artificial Intelligence](https://www.nscai.gov/home) qualifies as an executive branch agency subject to FISMA. This change adds the commission to the [agency list](https://cyber.dhs.gov/agencies/). It also retires the [National Commission on Military, National, and Public Service](https://inspire2serve.gov/).