### PR TITLE
Add United States Institute of Peace to agencylist.md

### DIFF
--- a/pages/agencylist.md
+++ b/pages/agencylist.md
@@ -105,6 +105,7 @@ The following civilian Executive Branch agencies fall under CISA's [authorities]
 | United States Agency for International Development | USAID
 | United States Commission on Civil Rights| USCCR
 | United States Department of Agriculture | USDA
+| United States Institute of Peace | USIP
 | United States Interagency Council on Homelessness | USICH
 | United States International Development Finance Corporation (formerly Overseas Private Investment Corporation) | DFC
 | United States International Trade Commission| USITC


### PR DESCRIPTION
It has been determined that United States Institute of Peace is a "agency" under [44 USC 3502](https://uscode.house.gov/view.xhtml?req=(title:44%20section:3502%20edition:prelim)%20OR%20(granuleid:USC-prelim-title44-section3502)&f=treesort&edition=prelim&num=0&jumpTo=true) and thus subject to CISA's directives. This PR adds USIP to the list.